### PR TITLE
Fixed typo in string formatting for listmembership creation.

### DIFF
--- a/pypardot/objects/listmemberships.py
+++ b/pypardot/objects/listmemberships.py
@@ -33,7 +33,7 @@ class ListMemberships(object):
             raise PardotAPIArgumentError('a list ID is required to create a list membership.')
         if not prospect_id:
             raise PardotAPIArgumentError('a prospect ID is required to create a list membership.')
-        response = self._post(path='/do/create/list_id/{email}/prospect_id/{prospect_id}'.format(list_id=list_id,prospect_id=prospect_id), params=kwargs)
+        response = self._post(path='/do/create/list_id/{list_id}/prospect_id/{prospect_id}'.format(list_id=list_id,prospect_id=prospect_id), params=kwargs)
         return response
     
     def read(self, list_id=None, prospect_id=None, **kwargs):


### PR DESCRIPTION
In listmembership creation url string was the `email` parameter, meanwhile in the format arguments no email parameter was specified but `list_id` was. According to docs http://developer.pardot.com/kb/api-version-4/list-memberships/ (see create operation) `list_id` is the right one.