### PR TITLE
Fix emailClicks query keyError bug

### DIFF
--- a/pypardot/objects/emailclicks.py
+++ b/pypardot/objects/emailclicks.py
@@ -17,9 +17,9 @@ class EmailClicks(object):
         # Ensure result['emailClicks'] is a list, no matter what.
         result = response.get('result')
         if result['total_results'] == 0:
-            result['emailClicks'] = []
+            result['emailClick'] = []
         elif result['total_results'] == 1:
-            result['emailClicks'] = [result['emailClicks']]
+            result['emailClick'] = [result['emailClick']]
 
         return result
 


### PR DESCRIPTION
The result contains the key emailClick so result['emailClicks'] raise keyError exception