### PR TITLE
fix list create and update by passing params

### DIFF
--- a/pypardot/objects/lists.py
+++ b/pypardot/objects/lists.py
@@ -34,14 +34,14 @@ class Lists(object):
         """
         Updates the provided data for the list specified by <id>. <id> is the Pardot ID of the list.
         """
-        response = self._post(path='/do/update/id/{id}'.format(id=id))
+        response = self._post(path='/do/update/id/{id}'.format(id=id), params=kwargs)
         return response
-    
+
     def create(self, **kwargs):
         """
         Creates a new list using the specified data.
         """
-        response = self._post(path='/do/create')
+        response = self._post(path='/do/create', params=kwargs)
         return response
 
     def delete(self, id=None):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="PyPardot4",
-    version="1.1.11",
+    version="1.1.12",
     author="Matt Needham",
     author_email="matthew.m.needham@gmail.com",
 	license="MIT",


### PR DESCRIPTION
The list create and update methods were missings the params argument. The Pardot API docs are incomplete - `name` is in fact a required param to create a list.