### PR TITLE
move POST data to post body add Pardot authorization header to GETs

### DIFF
--- a/pypardot/client.py
+++ b/pypardot/client.py
@@ -75,7 +75,7 @@ class PardotAPI(object):
         params.update({'user_key': self.user_key, 'api_key': self.api_key, 'format': 'json'})
         try:
             self._check_auth(object_name=object_name)
-            request = requests.post(self._full_path(object_name, self.version, path), params=params)
+            request = requests.post(self._full_path(object_name, self.version, path), data=params)
             response = self._check_response(request)
             return response
         except PardotAPIError as err:
@@ -93,10 +93,11 @@ class PardotAPI(object):
         """
         if params is None:
             params = {}
-        params.update({'user_key': self.user_key, 'api_key': self.api_key, 'format': 'json'})
+        params.update({'format': 'json'})
+        headers = self._build_auth_header()
         try:
             self._check_auth(object_name=object_name)
-            request = requests.get(self._full_path(object_name, self.version, path), params=params)
+            request = requests.get(self._full_path(object_name, self.version, path), params=params, headers=headers)
             response = self._check_response(request)
             return response
         except PardotAPIError as err:
@@ -163,3 +164,12 @@ class PardotAPI(object):
             return False
         except PardotAPIError:
             return False
+
+    def _build_auth_header(self):
+        """
+        Builds Pardot Authorization Header to be used with GET requests
+        """
+        if not self.user_key or not self.api_key:
+            raise Exception('Cannot build Authorization header. user or api key is empty')
+        auth_string = 'Pardot api_key=%s, user_key=%s' % (self.api_key, self.user_key)
+        return {'Authorization': auth_string}


### PR DESCRIPTION
Pardot is deprecating the use of credentials in the query string and is now requiring an Authorization headers in the format of `Pardot api_key=<api_key>, user_key=<user_key>` as per their API Docs
http://developer.pardot.com/#using-the-api

This change:
*  **moves** the POST params to the post body
* **removes** the credentials from the query string for GET requests
* **adds** the new Pardot authorization header to GET requests