### PR TITLE
Fixing authenticate handling in cases of some errors

### DIFF
--- a/pypardot/client.py
+++ b/pypardot/client.py
@@ -158,7 +158,10 @@ class PardotAPI(object):
         """
         try:
             auth = self.post('login', params={'email': self.email, 'password': self.password})
-            self.api_key = auth.get('api_key')
+            if type(auth) is int:
+                # sometimes the self.post method will return a status code instead of JSON response on failures
+                return False
+            self.api_key = auth.get('api_key', None)
             if self.api_key is not None:
                 return True
             return False


### PR DESCRIPTION
If you trace the `self.post()` code down to the `_check_response` method, the `self.post` code can actually return an integer status code. This breaks the `self.api_key = auth.get('api_key')` and raises an unhandled AttributeError.

Another way of fixing this would be to catch the AttributeError but I figured that was more Java-esque and less Pythonic.

Another way of fixing this would be for `self.post()` to *always* return a JSON response with a status code inside it, but that's a much bigger change with ramifications for consuming clients.

I also added a default return value for `auth.get('api_key')` since that would also raise an exception if that key doesn't exist in the dictionary.