### PR TITLE
Refactored docstrings in emails module

### DIFF
--- a/pypardot/objects/emails.py
+++ b/pypardot/objects/emails.py
@@ -1,16 +1,20 @@
 class Emails(object):
-    """
-    A class to query and send Pardot emails.
-    Email field reference: http://developer.pardot.com/kb/object-field-references/#email
+    """A class to query and send Pardot emails.
+
+    Email field reference:
+    http://developer.pardot.com/kb/object-field-references/#email
+
     """
 
     def __init__(self, client):
         self.client = client
 
     def send_to_email(self, prospect_email=None, **kwargs):
-        """
-        Sends an email to the prospect identified by <prospect_email>.
-        Required parameters: (email_template_id OR (text_content, name, subject, & ((from_email & from_name) OR from_user_id)))
+        """Sends an email to the prospect identified by <prospect_email>.
+
+        Required parameters: (email_template_id OR (text_content, name,
+        subject, & ((from_email & from_name) OR from_user_id)))
+
         """
         response = self._post(
             path='/do/send/prospect_email/{prospect_email}'.format(prospect_email=prospect_email),
@@ -18,18 +22,25 @@ class Emails(object):
         return response
 
     def send_to_id(self, prospect_id=None, **kwargs):
-        """
-        Sends an email to the prospect identified by <prospect_id>.
-        Required parameters: (email_template_id OR (text_content, name, subject, & ((from_email & from_name) OR from_user_id)))
+        """Sends an email to the prospect identified by <prospect_id>.
+
+        Required parameters: campaign_id, (email_template_id OR
+        (text_content, name, subject, & ((from_email & from_name) OR
+        from_user_id)))
+
+        API reference: http://developer.pardot.com/kb/api-version-4/emails/#sending-one-to-one-emails
+
         """
         response = self._post(
             path='/do/send/prospect_id/{prospect_id}'.format(prospect_id=prospect_id), params=kwargs)
         return response
 
     def send_to_lists(self, **kwargs):
-        """
-        Sends an email to the lists identified by list_ids[].
-        Required parameters: (email_template_id OR (text_content, name, subject, & ((from_email & from_name) OR from_user_id)))
+        """Sends an email to the lists identified by list_ids[]
+
+        Required parameters: (email_template_id OR (text_content, name,
+        subject, & ((from_email & from_name) OR from_user_id)))
+
         """
         kwargs['list_ids'] = kwargs.get('list_ids', None)
         response = self._post(
@@ -37,12 +48,21 @@ class Emails(object):
         return response
 
     def read(self, email_id=None):
-        """Returns the data for the email specified by <email_id>. <email_id> is the Pardot ID of the target email."""
+        """Returns the data for the email specified by <email_id>
+
+        <email_id> is the Pardot ID of the target email.
+
+        """
         response = self._post(path='/do/read/id/{email_id}'.format(email_id=email_id))
         return response
     
     def stats(self, list_email_id=None):
-        """Returns the statistical data for the list email specified by <list_email_id>. <list_email_id> is the Pardot ID of the target email."""
+        """Returns the statistical data for the list email
+        
+        Must be specified by <list_email_id>. <list_email_id> is the
+        Pardot ID of the target email.
+
+        """
         response = self._post(path='/do/stats/id/{list_email_id}'.format(list_email_id=list_email_id))
         return response
 


### PR DESCRIPTION
Needed to add that the campaign_id is required for method `emails.send_to_id`. Refactored docstrings, e.g. wrapped lines consistently. Edited docstrings only, didn't modify any code. 